### PR TITLE
Replace references by actual strings in German translation

### DIFF
--- a/custom_components/gardena_smart_system/translations/vacuum.de.json
+++ b/custom_components/gardena_smart_system/translations/vacuum.de.json
@@ -19,10 +19,10 @@
         "cleaning": "Mäht",
         "docked": "Angedockt",
         "error": "Fehler",
-        "idle": "[%key:common::state::idle%]",
-        "off": "[%key:common::state::off%]",
-        "on": "[%key:common::state::on%]",
-        "paused": "[%key:common::state::paused%]",
+        "idle": "Inaktiv",
+        "off": "Aus",
+        "on": "An",
+        "paused": "Pausiert",
         "returning": "Zurück zum Dock"
       }
     }


### PR DESCRIPTION
Fixes #149. These are the strings from the official Home Assistant translation. These words are basic so using a reference does not really win anything.