### PR TITLE
Set mower to idle state upon reaching daily limit

### DIFF
--- a/custom_components/gardena_smart_system/vacuum.py
+++ b/custom_components/gardena_smart_system/vacuum.py
@@ -16,6 +16,7 @@ from homeassistant.components.vacuum import (
     STATE_DOCKED,
     STATE_RETURNING,
     STATE_ERROR,
+    STATE_IDLE,
     ATTR_BATTERY_LEVEL,
 )
 
@@ -94,9 +95,12 @@ class GardenaSmartMower(StateVacuumEntity):
         state = self._device.state
         _LOGGER.debug("Mower has state %s", state)
         if state in ["WARNING", "ERROR", "UNAVAILABLE"]:
-            _LOGGER.debug("Mower has an error")
-            self._state = STATE_ERROR
             self._error_message = self._device.last_error_code
+            if self._device.last_error_code == "PARKED_DAILY_LIMIT_REACHED":
+                self._state = STATE_IDLE
+            else:
+                _LOGGER.debug("Mower has an error")
+                self._state = STATE_ERROR
         else:
             _LOGGER.debug("Getting mower state")
             activity = self._device.activity


### PR DESCRIPTION
This pull request resolves #34 by setting the mower in `idle` state upon reaching daily maximum work capacity.

In accordance with the GARDENA Operator's Manual, distinct mower models have varying maximum work capacity that either is defined by a minimum daily standby time or a maximum cutting time within a day.

Previously, upon reaching the daily limit, the mower's state was set to `error`, which implied a need for manual intervention to rectify the situation. However, the daily limit reached, is only a temporary state and resets automatically at midnight and eliminating the need for manual intervention.

My GARDENA smart SILENO life 700 LONA seems to have a maximum cutting time within a day of ~6 hours (338 minutes of cutting and 14 minutes of returning to dock to be exact):

![SILENO entity daily history towards reaching daily maximum work capacity](https://github.com/py-smart-gardena/hass-gardena-smart-system/assets/15981279/07e28df4-d4a9-42df-9079-6814ed09b548)

After ~6 hours of cutting and returning to the dock the state has been changed to `idle`, when using the changes in this commit.

![Logbook of SILENO events](https://github.com/py-smart-gardena/hass-gardena-smart-system/assets/15981279/2216d432-8ea0-408e-bec2-34d914e1f425)

Here's a snapshot of the state and the attributes after the mower has changed its state to `idle`.

![Current state of SILENO upon reaching daily maximum work capacity](https://github.com/py-smart-gardena/hass-gardena-smart-system/assets/15981279/7b5e7aa6-a507-404f-ad8e-47dbdbc08bbd)

Here's a snapshot from the GARDENA app for iOS:

![iOS app for SILENO smart upon reaching daily maximum work capacity](https://github.com/py-smart-gardena/hass-gardena-smart-system/assets/15981279/b513cd40-87f2-4b38-9826-01885079828f)