### PR TITLE
Fixes non async call async_forward_entry_setup

### DIFF
--- a/custom_components/gardena_smart_system/__init__.py
+++ b/custom_components/gardena_smart_system/__init__.py
@@ -61,9 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, lambda event: hass.async_create_task(gardena_system.stop()))
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component))
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     _LOGGER.debug("Gardena Smart System component setup finished")
     return True


### PR DESCRIPTION
Fixes issue #217.

Reference: [Forwarding setup to config entry platforms](https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/).