### PR TITLE
Changed start behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 # Home Assistant integration for Gardena Smart System
 # Modified by Purtzel
 
+# Changes the behavior of the startup to go to normal schedule instead of override mode. Adds “clean_spot” command to vaccum to start override mode.
+
 Custom component to support Gardena Smart System devices.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![hass-gardena-smart-system](https://img.shields.io/github/release/py-smart-gardena/hass-gardena-smart-system.svg?1)](https://github.com/py-smart-gardena/hass-gardena-smart-system)
 
 # Home Assistant integration for Gardena Smart System
+# Modified by Purtzel
 
 Custom component to support Gardena Smart System devices.
 

--- a/custom_components/gardena_smart_system/vacuum.py
+++ b/custom_components/gardena_smart_system/vacuum.py
@@ -184,12 +184,20 @@ class GardenaSmartMower(StateVacuumEntity):
     def option_mower_duration(self) -> int:
         return self._options.get(CONF_MOWER_DURATION, DEFAULT_MOWER_DURATION)
 
-    def start(self):
+    def clean_spot(self):
+        """Purtzel: Clean Spot ruft nun START_SECONDS_TO_OVERRIDE auf """
         """Start the mower using Gardena API command START_SECONDS_TO_OVERRIDE. Duration is read from integration options."""
         duration = self.option_mower_duration * 60
         _LOGGER.debug("Mower command:  vacuum.start => START_SECONDS_TO_OVERRIDE, %s", duration)
         return asyncio.run_coroutine_threadsafe(
             self._device.start_seconds_to_override(duration), self.hass.loop
+        ).result()
+    
+    def start(self):
+        """Purtzel: ruft nun START_DONT_OVERRIDE auf """        
+        _LOGGER.debug("Mower command:  vacuum.start => START_DONT_OVERRIDE")
+        return asyncio.run_coroutine_threadsafe(
+            self._device.start_dont_override(), self.hass.loop
         ).result()
 
     def stop(self, **kwargs):


### PR DESCRIPTION
Hello,

I have adjusted the behavior of the robotic lawnmower so that the robot does not go into “start override” mode when starting, but into normal start mode. I have implemented the clean spot command to let the robot run for a specified time (“start override”). This together makes it possible, for example, to send the robot home weather-controlled and it can then resume its normal work schedule.

Purtzel
