### PR TITLE
Fix config options flow

### DIFF
--- a/custom_components/gardena_smart_system/config_flow.py
+++ b/custom_components/gardena_smart_system/config_flow.py
@@ -81,11 +81,11 @@ class GardenaSmartSystemConfigFlowHandler(config_entries.ConfigFlow, domain=DOMA
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        return GardenaSmartSystemOptionsFlowHandler(config_entry)
+        return GardenaSmartSystemOptionsFlowHandler()
 
 
 class GardenaSmartSystemOptionsFlowHandler(config_entries.OptionsFlow):
-    def __init__(self, config_entry):
+    def __init__(self):
         """Initialize Gardena Smart System options flow."""
         super().__init__()
 


### PR DESCRIPTION
Opens Gardena Smart System config pane again on my HA setup.
Method no longer has `config_entry` parameter.
Expected to fix issue #287