### PR TITLE
Fix service command execution in GardenaServiceManager

### DIFF
--- a/custom_components/gardena_smart_system/services.py
+++ b/custom_components/gardena_smart_system/services.py
@@ -218,6 +218,8 @@ class GardenaServiceManager:
     def _get_coordinator(self, device_id: str) -> Optional[GardenaSmartSystemCoordinator]:
         """Get coordinator for device."""
         for entry_id in self.hass.data[DOMAIN]:
+            if entry_id == "service_manager":
+                continue
             coordinator = self.hass.data[DOMAIN][entry_id]
             device = coordinator.get_device_by_id(device_id)
             if device:
@@ -251,7 +253,7 @@ class GardenaServiceManager:
             return False
         
         try:
-            await coordinator.client.send_command(service_id, command.to_dict())
+            await coordinator.client.send_command(service_id, {"data": command.to_dict()})
             _LOGGER.debug(f"Command {command.command_type} sent successfully to {service_id}")
             return True
         except Exception as e:

--- a/custom_components/gardena_smart_system/services.py
+++ b/custom_components/gardena_smart_system/services.py
@@ -16,11 +16,13 @@ _LOGGER = logging.getLogger(__name__)
 
 # Service schemas
 SERVICE_SCHEMA_BASE = vol.Schema({
-    vol.Required("device_id"): cv.string,  # Use string for now, will be validated in service
+    vol.Required("device_id"): cv.string,
+    vol.Optional("service_id"): cv.string,
 })
 
 SERVICE_SCHEMA_DURATION = vol.Schema({
     vol.Required("device_id"): cv.string,
+    vol.Optional("service_id"): cv.string,
     vol.Optional("duration", default=3600): vol.All(
         cv.positive_int, vol.Range(min=60, max=86400)
     ),
@@ -28,6 +30,7 @@ SERVICE_SCHEMA_DURATION = vol.Schema({
 
 SERVICE_SCHEMA_MOWER = vol.Schema({
     vol.Required("device_id"): cv.string,
+    vol.Optional("service_id"): cv.string,
     vol.Optional("duration", default=1800): vol.All(
         cv.positive_int, vol.Range(min=60, max=14400)
     ),
@@ -35,6 +38,7 @@ SERVICE_SCHEMA_MOWER = vol.Schema({
 
 SERVICE_SCHEMA_VALVE = vol.Schema({
     vol.Required("device_id"): cv.string,
+    vol.Optional("service_id"): cv.string,
     vol.Optional("duration", default=3600): vol.All(
         cv.positive_int, vol.Range(min=60, max=14400)
     ),
@@ -231,11 +235,11 @@ class GardenaServiceManager:
         coordinator = self._get_coordinator(device_id)
         if not coordinator:
             return None
-        
+
         device = coordinator.get_device_by_id(device_id)
         if not device or service_type not in device.services:
             return None
-        
+
         # Handle list of services (for devices with multiple services of same type)
         services = device.services[service_type]
         if isinstance(services, list) and len(services) > 0:
@@ -368,44 +372,44 @@ class GardenaServiceManager:
         """Open valve for specified duration."""
         device_id = call.data["device_id"]
         duration = call.data["duration"]
-        service_id = self._get_device_service_id(device_id, "VALVE")
+        service_id = call.data.get("service_id") or self._get_device_service_id(device_id, "VALVE")
         if not service_id:
             _LOGGER.error(f"No VALVE service found for device {device_id}")
             return
-        
+
         command = ValveCommand(service_id, "START_SECONDS_TO_OVERRIDE", seconds=duration)
         await self._send_command(service_id, command)
 
     async def _service_valve_close(self, call: ServiceCall) -> None:
         """Close valve."""
         device_id = call.data["device_id"]
-        service_id = self._get_device_service_id(device_id, "VALVE")
+        service_id = call.data.get("service_id") or self._get_device_service_id(device_id, "VALVE")
         if not service_id:
             _LOGGER.error(f"No VALVE service found for device {device_id}")
             return
-        
+
         command = ValveCommand(service_id, "STOP_UNTIL_NEXT_TASK")
         await self._send_command(service_id, command)
 
     async def _service_valve_pause(self, call: ServiceCall) -> None:
         """Pause valve operation."""
         device_id = call.data["device_id"]
-        service_id = self._get_device_service_id(device_id, "VALVE")
+        service_id = call.data.get("service_id") or self._get_device_service_id(device_id, "VALVE")
         if not service_id:
             _LOGGER.error(f"No VALVE service found for device {device_id}")
             return
-        
+
         command = ValveCommand(service_id, "PAUSE")
         await self._send_command(service_id, command)
 
     async def _service_valve_unpause(self, call: ServiceCall) -> None:
         """Unpause valve operation."""
         device_id = call.data["device_id"]
-        service_id = self._get_device_service_id(device_id, "VALVE")
+        service_id = call.data.get("service_id") or self._get_device_service_id(device_id, "VALVE")
         if not service_id:
             _LOGGER.error(f"No VALVE service found for device {device_id}")
             return
-        
+
         command = ValveCommand(service_id, "UNPAUSE")
         await self._send_command(service_id, command)
 

--- a/custom_components/gardena_smart_system/valve.py
+++ b/custom_components/gardena_smart_system/valve.py
@@ -119,9 +119,17 @@ class GardenaWaterControl(GardenaEntity, ValveEntity):
         """Return true if valve is closing."""
         return False
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return entity specific state attributes."""
+        attrs = super().extra_state_attributes
+        attrs["service_id"] = self.valve_service.id
+        return attrs
+
     async def async_open_valve(self, **kwargs: Any) -> None:
         """Open the valve."""
-        _LOGGER.info(f"=== OPEN_VALVE called for Water Control {self.device.name} ===")
+        duration = kwargs.get("duration", 3600)
+        _LOGGER.info(f"=== OPEN_VALVE called for Water Control {self.device.name} ({duration}s) ===")
         _LOGGER.info(f"Opening Water Control {self.device.name} ({self.valve_service.id})")
         if self.valve_service:
             command_data = {
@@ -130,7 +138,7 @@ class GardenaWaterControl(GardenaEntity, ValveEntity):
                     "type": "VALVE_CONTROL",
                     "attributes": {
                         "command": "START_SECONDS_TO_OVERRIDE",
-                        "seconds": 3600,  # Default 1 hour
+                        "seconds": duration,
                     },
                 }
             }
@@ -173,6 +181,7 @@ class GardenaWaterControl(GardenaEntity, ValveEntity):
                 raise
         else:
             _LOGGER.error(f"No valve service available for Water Control {self.device.name}")
+
 
 
 class GardenaSmartIrrigationControl(GardenaEntity, ValveEntity):
@@ -234,9 +243,17 @@ class GardenaSmartIrrigationControl(GardenaEntity, ValveEntity):
         """Return true if valve is closing."""
         return False
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return entity specific state attributes."""
+        attrs = super().extra_state_attributes
+        attrs["service_id"] = self.valve_service.id
+        return attrs
+
     async def async_open_valve(self, **kwargs: Any) -> None:
         """Open the valve."""
-        _LOGGER.info(f"=== OPEN_VALVE called for Smart Irrigation Control valve {self._attr_name} ===")
+        duration = kwargs.get("duration", 3600)
+        _LOGGER.info(f"=== OPEN_VALVE called for Smart Irrigation Control valve {self._attr_name} ({duration}s) ===")
         _LOGGER.info(f"Opening Smart Irrigation Control valve {self._attr_name} ({self.valve_service.id})")
         if self.valve_service:
             command_data = {
@@ -245,7 +262,7 @@ class GardenaSmartIrrigationControl(GardenaEntity, ValveEntity):
                     "type": "VALVE_CONTROL",
                     "attributes": {
                         "command": "START_SECONDS_TO_OVERRIDE",
-                        "seconds": 3600,  # Default 1 hour
+                        "seconds": duration,
                     },
                 }
             }
@@ -288,6 +305,7 @@ class GardenaSmartIrrigationControl(GardenaEntity, ValveEntity):
                 raise
         else:
             _LOGGER.error(f"No valve service available for Smart Irrigation Control valve {self._attr_name}")
+
 
 
 class GardenaValve(GardenaEntity, ValveEntity):
@@ -352,9 +370,17 @@ class GardenaValve(GardenaEntity, ValveEntity):
         # Valve goes directly from WATERING to CLOSED
         return False
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return entity specific state attributes."""
+        attrs = super().extra_state_attributes
+        attrs["service_id"] = self.valve_service.id
+        return attrs
+
     async def async_open_valve(self, **kwargs: Any) -> None:
         """Open the valve."""
-        _LOGGER.info(f"Opening valve {self.valve_service.name} ({self.valve_service.id})")
+        duration = kwargs.get("duration", 3600)
+        _LOGGER.info(f"Opening valve {self.valve_service.name} for {duration}s ({self.valve_service.id})")
         if self.valve_service:
             command_data = {
                 "data": {
@@ -362,7 +388,7 @@ class GardenaValve(GardenaEntity, ValveEntity):
                     "type": "VALVE_CONTROL",
                     "attributes": {
                         "command": "START_SECONDS_TO_OVERRIDE",
-                        "seconds": 3600,  # Default 1 hour
+                        "seconds": duration,
                     },
                 }
             }
@@ -396,3 +422,4 @@ class GardenaValve(GardenaEntity, ValveEntity):
                 raise
         else:
             _LOGGER.error(f"No valve service available for {self.valve_service.name}")
+


### PR DESCRIPTION
## Summary

- **Skip `service_manager` key** in `_get_coordinator()`: When iterating over `hass.data[DOMAIN]`, the `"service_manager"` entry is not a coordinator object and causes an `AttributeError` when calling `get_device_by_id()` on it.
- **Wrap command in `{"data": ...}` envelope** in `_send_command()`: The Gardena Smart System API expects the command payload wrapped in a `data` key. Without this, commands (mower start/park, valve open/close, etc.) are silently rejected.
- **Multi-valve fix**: Valve service handlers now accept an optional `service_id` parameter to target a specific valve on multi-valve devices (e.g. Irrigation Control with 6 zones). Falls back to `_get_device_service_id()` for single-valve devices.
- **Expose `service_id` attribute**: All valve entity classes (`GardenaSmartValve`, `GardenaSmartIrrigationControl`, `GardenaSmartWaterControl`) now expose `service_id` via `extra_state_attributes`, enabling the Lovelace card to target individual valves.
- **Optional duration for valve open**: `async_open_valve()` now accepts an optional `duration` kwarg (default: 3600s), allowing callers to specify watering duration.

## Test plan

- [x] Verified mower services (`mower_start_manual`, `mower_park`, `mower_park_until_notice`) execute correctly with the `data` envelope
- [x] Verified `_get_coordinator` no longer throws when `service_manager` key is present in `hass.data[DOMAIN]`
- [x] Verified existing valve and socket services still work as expected
- [x] Verify valve `service_id` targeting on multi-valve devices (Irrigation Control)
- [x] Verify backwards compatibility: valve services without `service_id` still work (falls back to first service)
- [x] Verify `duration` parameter is correctly passed through to `async_open_valve()`