### PR TITLE
fix: added token refresh to websocket url retrieval

### DIFF
--- a/custom_components/gardena_smart_system/auth.py
+++ b/custom_components/gardena_smart_system/auth.py
@@ -109,6 +109,19 @@ class GardenaAuthenticationManager:
                 _LOGGER.debug("Using existing valid access token")
                 return self._access_token
 
+            # Try to refresh token if we have a refresh token
+            if self._refresh_token:
+                try:
+                    _LOGGER.debug("Token expired, attempting to refresh")
+                    await self._refresh_access_token()
+                    return self._access_token
+                except GardenaAuthError as e:
+                    _LOGGER.warning(f"Token refresh failed: {e}, performing new authentication")
+                    # Clear tokens and fall through to new authentication
+                    self._access_token = None
+                    self._refresh_token = None
+                    self._token_expires_at = None
+
             # Perform new authentication
             _LOGGER.debug("Performing new authentication")
             session = await self._get_session()

--- a/custom_components/gardena_smart_system/websocket_client.py
+++ b/custom_components/gardena_smart_system/websocket_client.py
@@ -144,6 +144,9 @@ class GardenaWebSocketClient:
     async def _get_websocket_url(self) -> None:
         """Get WebSocket URL from Gardena API."""
         try:
+            # Ensure we have a valid token before making the request
+            await self.auth_manager.authenticate()
+
             headers = self.auth_manager.get_auth_headers()
             session = await self.auth_manager._get_session()
             


### PR DESCRIPTION
This PR adds token refresh to the `_get_websocket_url()` function to assure valid credentials all the time. Furthermore, it slightly improves the `authenticate()` function by checking for a refresh token to make the re-authentication more efficient.

Fixes #302, Fixes #303