### PR TITLE
fix: show battery sensor for soil moisture sensors with null battery_state

### DIFF
--- a/custom_components/gardena_smart_system/sensor.py
+++ b/custom_components/gardena_smart_system/sensor.py
@@ -42,8 +42,14 @@ async def async_setup_entry(
                 common_services = device.services["COMMON"]
                 _LOGGER.debug(f"Found {len(common_services)} common services for device: {device.name} ({device.id})")
                 for common_service in common_services:
-                    # Only create battery sensor if device has a battery
-                    if common_service.battery_state and common_service.battery_state not in ["NO_BATTERY"]:
+                    # Only create battery sensor if device has a battery.
+                    # Include when battery_level is present even if battery_state is not yet
+                    # populated (soil sensors can return null battery_state at initial load).
+                    has_battery = (
+                        common_service.battery_state not in [None, "NO_BATTERY"]
+                        or common_service.battery_level is not None
+                    )
+                    if has_battery:
                         _LOGGER.debug(f"Creating battery sensor for device with battery: {device.name} (battery_state: {common_service.battery_state})")
                         entities.append(GardenaBatterySensor(coordinator, device, common_service))
                     else:


### PR DESCRIPTION
## Summary

- Battery sensor was never created for GARDENA smart Sensor (soil moisture) devices because the guard condition required `battery_state` to be a non-empty string
- Soil sensors can return `battery_state=None` at initial API load even when `battery_level` is populated
- The fix checks **either** field: if `battery_state` is explicitly `"NO_BATTERY"` the sensor is excluded (wired/gateway devices), otherwise if `battery_level` is present a battery entity is created

## Root cause

In `sensor.py` line 46, the old condition:
```python
if common_service.battery_state and common_service.battery_state not in ["NO_BATTERY"]:
```
silently dropped battery sensors when `battery_state` was `None`, even when `battery_level` was available.

## Fix

```python
has_battery = (
    common_service.battery_state not in [None, "NO_BATTERY"]
    or common_service.battery_level is not None
)
if has_battery:
```

## Note for existing installations

Users who already have the integration installed will need to **reload the integration once** (Settings → Devices & Services → Gardena → ⋮ → Reload) for the new battery entity to appear. On reload, HA tears down and rebuilds the integration with a fresh API fetch, so the battery sensor is registered cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)