### PR TITLE
fix: replace non-existent UnitOfIlluminance with LIGHT_LUX (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `ImportError: cannot import name 'UnitOfIlluminance'` preventing the integration from loading; replaced non-existent `UnitOfIlluminance.LUX` with the `LIGHT_LUX` constant (#351)
+
 ## [3.0.0] - 2026-05-13
 
 ### Breaking Changes

--- a/custom_components/gardena_smart_system/sensor.py
+++ b/custom_components/gardena_smart_system/sensor.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfIlluminance, UnitOfTemperature, UnitOfTime
+from homeassistant.const import LIGHT_LUX, PERCENTAGE, UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -422,7 +422,7 @@ class GardenaLightSensor(GardenaEntity, SensorEntity):
         self._device_id = device.id
         self._attr_name = f"{device.name} Light Intensity"
         self._attr_unique_id = f"{device.id}_{sensor_service.id}_light_intensity"
-        self._attr_native_unit_of_measurement = UnitOfIlluminance.LUX
+        self._attr_native_unit_of_measurement = LIGHT_LUX
         self._attr_device_class = SensorDeviceClass.ILLUMINANCE
         self._attr_icon = "mdi:white-balance-sunny"
 


### PR DESCRIPTION
## Summary

The fix for #351 (commit 27b81cd) imported `UnitOfIlluminance` from `homeassistant.const`, but **that class does not exist** in Home Assistant — `homeassistant.const` only exposes the `LIGHT_LUX = "lx"` constant for illuminance.

This caused the integration to fail at startup with:

```
ImportError: cannot import name 'UnitOfIlluminance' from 'homeassistant.const'
  File "/config/custom_components/gardena_smart_system/sensor.py", line 10, in <module>
    from homeassistant.const import PERCENTAGE, UnitOfIlluminance, UnitOfTemperature, UnitOfTime
```

The integration no longer loads at all in v3.0.0.

## Fix

- Import `LIGHT_LUX` instead of the non-existent `UnitOfIlluminance`
- Assign `LIGHT_LUX` (string `"lx"`) to `_attr_native_unit_of_measurement` for the light sensor

This still resolves the original #351 concern (using `"lx"` instead of `"lux"`) — `LIGHT_LUX` is the official HA constant and resolves to `"lx"`.

## Test plan

- [x] `python -m py_compile custom_components/gardena_smart_system/sensor.py`
- [x] Restart HA with a soil sensor / light sensor device — verify the integration loads without `ImportError`
- [ ] Verify the light intensity sensor shows unit `lx`

## References

- Closes #351 properly (previous fix in 27b81cd broke the integration)
- HA `LIGHT_LUX` definition: https://github.com/home-assistant/core/blob/dev/homeassistant/const.py