### PR TITLE
fix: correct command format for service calls to fix 504 errors (#361)

### DIFF
--- a/custom_components/gardena_smart_system/services.py
+++ b/custom_components/gardena_smart_system/services.py
@@ -57,14 +57,14 @@ class GardenaCommand:
         self.attributes = kwargs
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert command to API format."""
+    """Convert command to API format."""
         return {
-            "data": {
-                "id": f"cmd_{self.service_id}_{self.command_type}",
-                "type": self.command_type,
-                "attributes": self.attributes,
-            }
+        "data": {
+            "type": self.command_type,
+            "attributes": self.attributes,
         }
+    }
+
 
 
 class MowerCommand(GardenaCommand):
@@ -79,11 +79,10 @@ class MowerCommand(GardenaCommand):
     
     def __init__(self, service_id: str, command: str, seconds: Optional[int] = None):
         """Initialize mower command."""
-        super().__init__(service_id, "MOWER_CONTROL")
+        super().__init__(service_id, "MOWER")
         self.attributes["command"] = command
         if seconds and command == "START_SECONDS_TO_OVERRIDE":
-            self.attributes["seconds"] = seconds
-
+            self.attributes["duration"] = seconds
 
 class PowerSocketCommand(GardenaCommand):
     """Power socket-specific commands."""


### PR DESCRIPTION
- Remove unnecessary 'id' field from command payload
- Simplify command type to match API expectations (MOWER, POWER_SOCKET, VALVE)
- Change 'seconds' to 'duration' in command attributes
- Fixes issue where service calls fail with 504 Server errors

Resolves: #361