### PR TITLE
fix: filter informational codes from mower_error sensor (#365)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `mower_error` sensor now returns `no_message` for informational operational states instead of surfacing them as errors. The following states no longer trigger error-based automations: `parked_daily_limit_reached`, `outside_working_area`, `off_disabled`, `off_hatch_open`, `off_hatch_closed`, `wait_updating`, `wait_power_up`, `wait_stop_pressed`, `wait_for_safety_pin`, `guide_calibration_accomplished`, `connection_changed`, `connection_not_changed`, `uninitialised` (#365)
+
 ## [3.0.3] - 2026-05-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -91,6 +91,28 @@ This ensures a clean installation and prevents any conflicts between the old and
 - Return to charging station
 - State and activity monitoring
 
+#### Mower error sensor
+
+The `mower_error` sensor exposes the `last_error_code` field from the Gardena API. To avoid false positives in error-notification automations, **informational operational states are filtered** and reported as `no_message` instead:
+
+| Code filtered | Meaning |
+|---|---|
+| `parked_daily_limit_reached` | Daily mowing limit reached — normal operation |
+| `outside_working_area` | Mower returned outside its zone — normal |
+| `off_disabled` | Disabled manually by user |
+| `off_hatch_open` | Hatch opened for maintenance |
+| `off_hatch_closed` | Hatch closed — normal state |
+| `wait_updating` | Firmware update in progress |
+| `wait_power_up` | Booting up |
+| `wait_stop_pressed` | Stop button held — user maintenance |
+| `wait_for_safety_pin` | Waiting for safety pin — user maintenance |
+| `guide_calibration_accomplished` | Calibration completed successfully |
+| `connection_changed` | Network state change — informational |
+| `connection_not_changed` | Network state change — informational |
+| `uninitialised` | Normal boot state |
+
+This means a simple automation like `state != 'no_message'` reliably catches only real errors that require attention.
+
 ## 🔧 Available Services
 
 The integration provides several services that can be called from automations, scripts, or the Developer Tools. All services require a `device_id` parameter.

--- a/custom_components/gardena_smart_system/const.py
+++ b/custom_components/gardena_smart_system/const.py
@@ -81,6 +81,26 @@ MOWER_ACTIVITY_MAP: Final = {
     MOWER_ACTIVITY_NONE: LawnMowerActivity.ERROR,
 }
 
+# Mower informational codes — operational states that are NOT errors.
+# The mower_error sensor returns "no_message" when last_error_code is in this set
+# so that user automations trigger only on real actionable errors.
+MOWER_INFORMATIONAL_CODES: Final = frozenset({
+    "no_message",                   # Already "no error"
+    "uninitialised",                # Normal boot state
+    "parked_daily_limit_reached",   # Daily schedule limit reached — normal operation
+    "outside_working_area",         # Mower returned to base outside its zone — normal
+    "off_disabled",                 # Disabled manually by user
+    "off_hatch_open",               # Hatch open for maintenance
+    "off_hatch_closed",             # Hatch closed — normal state
+    "wait_updating",                # Firmware update in progress
+    "wait_power_up",                # Booting up
+    "wait_stop_pressed",            # Stop button held — user-initiated maintenance
+    "wait_for_safety_pin",          # Waiting for safety pin — user-initiated maintenance
+    "guide_calibration_accomplished",  # Calibration completed successfully
+    "connection_changed",           # Network state change — informational
+    "connection_not_changed",       # Network state change — informational
+})
+
 # WebSocket configuration
 WEBSOCKET_RECONNECT_DELAY: Final = 5  # seconds
 WEBSOCKET_MAX_RECONNECT_ATTEMPTS: Final = 10

--- a/custom_components/gardena_smart_system/sensor.py
+++ b/custom_components/gardena_smart_system/sensor.py
@@ -16,6 +16,7 @@ from .const import (
     ATTR_BATTERY_STATE,
     ATTR_RF_LINK_LEVEL,
     ATTR_RF_LINK_STATE,
+    MOWER_INFORMATIONAL_CODES,
 )
 from .coordinator import GardenaSmartSystemCoordinator
 from .entities import GardenaEntity
@@ -239,13 +240,16 @@ class GardenaMowerErrorSensor(GardenaEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        """Return the last error code."""
+        """Return the last error code, or 'no_message' for informational states."""
         current_service = self._get_current_mower_service()
         if not current_service:
             return None
         error_code = current_service.last_error_code
         if error_code:
-            return error_code.lower()
+            code = error_code.lower()
+            if code in MOWER_INFORMATIONAL_CODES:
+                return "no_message"
+            return code
         return "no_message"
 
     @property


### PR DESCRIPTION
## Summary

Fixes #365 — `parked_daily_limit_reached` (and similar operational states) no longer triggers error-based automations.

The `mower_error` sensor was exposing every `last_error_code` value from the Gardena API as-is. But several of those codes are informational operational states, not actual errors — most notably `parked_daily_limit_reached`, which means the mower is happily docked after completing its daily quota.

## Changes

- **`const.py`** — New `MOWER_INFORMATIONAL_CODES` frozenset listing 13 codes that should not be treated as errors.
- **`sensor.py`** — `GardenaMowerErrorSensor.native_value` now returns `no_message` when `last_error_code` matches an informational code, instead of surfacing the raw value.
- **`README.md`** — New section under *Lawn Mower Features* documenting the filter and listing all filtered codes.
- **`CHANGELOG.md`** — Entry under `[Unreleased]`.

## Filtered codes

`parked_daily_limit_reached`, `outside_working_area`, `off_disabled`, `off_hatch_open`, `off_hatch_closed`, `wait_updating`, `wait_power_up`, `wait_stop_pressed`, `wait_for_safety_pin`, `guide_calibration_accomplished`, `connection_changed`, `connection_not_changed`, `uninitialised`

## Behaviour change

Users with automations matching specific informational codes (e.g. `state == 'parked_daily_limit_reached'`) will see those evaluate as `no_message` after this change. The `last_error_code` raw value is still available on the lawn mower entity's `extra_state_attributes` (`last_error_code` attribute) for users who want the unfiltered value.

The simple pattern `state != 'no_message'` now reliably catches only real, actionable errors.

Closes #365