### PR TITLE
Add reconfigure flow and services to update Husqvarna API credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [3.0.7] - 2026-05-27
+
+### Added
+
+- Reconfigure config flow to update Husqvarna Application Key and Client Secret without removing the integration
+- `gardena_smart_system.update_credentials` service to validate and save new API credentials (works while the integration is disabled)
+- `gardena_smart_system.start_reconfigure` service to open the credential dialog (works while the integration is disabled)
+- Shared credential validation module with clearer 429 rate-limit handling during setup
+
 ## [3.0.5] - 2026-05-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [3.0.7] - 2026-05-27
-
 ### Added
 
 - Reconfigure config flow to update Husqvarna Application Key and Client Secret without removing the integration

--- a/custom_components/gardena_smart_system/__init__.py
+++ b/custom_components/gardena_smart_system/__init__.py
@@ -1,16 +1,38 @@
 """Support for Gardena Smart System devices."""
 import logging
 
+import voluptuous as vol
+
+from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceEntry
 
-from .const import DOMAIN
+from .const import CONF_CONFIG_ENTRY_ID, DOMAIN
 from .coordinator import GardenaSmartSystemCoordinator
+from .credential_validation import (
+    SERVICE_ERROR_MESSAGES,
+    async_validate_gardena_credentials,
+)
 from .services import GardenaServiceManager
 
 _LOGGER = logging.getLogger(__name__)
+
+SERVICE_SCHEMA_UPDATE_CREDENTIALS = vol.Schema(
+    {
+        vol.Optional(CONF_CONFIG_ENTRY_ID): str,
+        vol.Required(CONF_CLIENT_ID): str,
+        vol.Required(CONF_CLIENT_SECRET): str,
+    }
+)
+
+SERVICE_SCHEMA_START_RECONFIGURE = vol.Schema(
+    {
+        vol.Optional(CONF_CONFIG_ENTRY_ID): str,
+    }
+)
 
 PLATFORMS = [
     Platform.LAWN_MOWER,
@@ -34,12 +56,78 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         hass.data[DOMAIN]["service_manager"] = service_manager
         _LOGGER.info("Gardena Smart System services initialized")
 
+    def _get_config_entry(config_entry_id: str | None) -> ConfigEntry:
+        """Resolve the Gardena config entry."""
+        if config_entry_id:
+            entry = hass.config_entries.async_get_entry(config_entry_id)
+            if entry is None or entry.domain != DOMAIN:
+                raise ServiceValidationError(
+                    f"Unknown Gardena config entry: {config_entry_id}"
+                )
+            return entry
+
+        entries = hass.config_entries.async_entries(DOMAIN)
+        if not entries:
+            raise ServiceValidationError("Gardena Smart System is not configured")
+        if len(entries) > 1:
+            raise ServiceValidationError(
+                "config_entry_id is required when multiple Gardena entries exist"
+            )
+        return entries[0]
+
     async def _async_reload_service(call: ServiceCall) -> None:
         """Reload all config entries for this integration."""
         for entry in hass.config_entries.async_entries(DOMAIN):
             await hass.config_entries.async_reload(entry.entry_id)
 
+    async def _async_update_credentials_service(call: ServiceCall) -> None:
+        """Validate and store API credentials (works while integration is disabled)."""
+        entry = _get_config_entry(call.data.get(CONF_CONFIG_ENTRY_ID))
+        user_input = {
+            CONF_CLIENT_ID: call.data[CONF_CLIENT_ID],
+            CONF_CLIENT_SECRET: call.data[CONF_CLIENT_SECRET],
+        }
+        errors = await async_validate_gardena_credentials(user_input)
+        if errors:
+            error_key = errors.get("base", "unknown")
+            message = SERVICE_ERROR_MESSAGES.get(error_key, error_key)
+            raise ServiceValidationError(message)
+
+        hass.config_entries.async_update_entry(entry, data=user_input)
+        if entry.disabled_by is None:
+            await hass.config_entries.async_reload(entry.entry_id)
+            _LOGGER.info("Gardena credentials updated and integration reloaded")
+        else:
+            _LOGGER.info(
+                "Gardena credentials updated for disabled entry %s; "
+                "enable the integration to connect",
+                entry.entry_id,
+            )
+
+    async def _async_start_reconfigure_service(call: ServiceCall) -> None:
+        """Open the credential dialog (works while integration is disabled)."""
+        entry = _get_config_entry(call.data.get(CONF_CONFIG_ENTRY_ID))
+        await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_RECONFIGURE,
+                "entry_id": entry.entry_id,
+            },
+        )
+
     hass.services.async_register(DOMAIN, "reload", _async_reload_service)
+    hass.services.async_register(
+        DOMAIN,
+        "update_credentials",
+        _async_update_credentials_service,
+        schema=SERVICE_SCHEMA_UPDATE_CREDENTIALS,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "start_reconfigure",
+        _async_start_reconfigure_service,
+        schema=SERVICE_SCHEMA_START_RECONFIGURE,
+    )
 
     return True
 

--- a/custom_components/gardena_smart_system/config_flow.py
+++ b/custom_components/gardena_smart_system/config_flow.py
@@ -11,8 +11,7 @@ from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
-from .gardena_client import GardenaAPIError, GardenaSmartSystemClient
-from .auth import GardenaAuthError
+from .credential_validation import async_validate_gardena_credentials
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,68 +21,82 @@ class GardenaSmartSystemConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def _credentials_schema(self) -> vol.Schema:
+        """Schema for API credential input."""
+        return vol.Schema(
+            {
+                vol.Required(CONF_CLIENT_ID): str,
+                vol.Required(CONF_CLIENT_SECRET): str,
+            }
+        )
+
+    async def _apply_credential_updates(
+        self,
+        entry: config_entries.ConfigEntry,
+        user_input: dict[str, Any],
+    ) -> FlowResult:
+        """Persist credentials; reload only when the config entry is enabled."""
+        self.hass.config_entries.async_update_entry(
+            entry,
+            data={
+                CONF_CLIENT_ID: user_input[CONF_CLIENT_ID],
+                CONF_CLIENT_SECRET: user_input[CONF_CLIENT_SECRET],
+            },
+        )
+        if entry.disabled_by is None:
+            await self.hass.config_entries.async_reload(entry.entry_id)
+        else:
+            _LOGGER.info(
+                "Credentials updated for disabled config entry %s; "
+                "enable the integration to connect",
+                entry.entry_id,
+            )
+        return self.async_abort(reason="reconfigure_successful")
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            try:
-                _LOGGER.info("Testing Gardena Smart System credentials")
-
-                # Test the credentials
-                import os
-                dev_mode = os.getenv('GARDENA_DEV_MODE', 'false').lower() == 'true'
-                client = GardenaSmartSystemClient(
-                    client_id=user_input[CONF_CLIENT_ID],
-                    client_secret=user_input[CONF_CLIENT_SECRET],
-                    dev_mode=dev_mode,  # Enable dev mode for SSL issues on macOS
+            errors = await async_validate_gardena_credentials(user_input)
+            if not errors:
+                return self.async_create_entry(
+                    title="Gardena Smart System",
+                    data=user_input,
                 )
 
-                # Try to authenticate and get locations
-                locations = await client.get_locations()
-
-                if not locations:
-                    _LOGGER.warning("No locations found for the provided credentials")
-                    errors["base"] = "no_locations"
-                else:
-                    _LOGGER.info("Successfully authenticated and found %d locations", len(locations))
-
-                    # If we get here, the credentials are valid
-                    return self.async_create_entry(
-                        title="Gardena Smart System",
-                        data=user_input,
-                    )
-
-            except GardenaAuthError as ex:
-                _LOGGER.error("Authentication failed: %s", ex)
-                errors["base"] = "invalid_auth"
-            except GardenaAPIError as ex:
-                _LOGGER.error("API error during configuration: %s (status: %s)", ex, ex.status_code)
-                if ex.status_code == 404:
-                    errors["base"] = "no_locations"
-                else:
-                    errors["base"] = "api_error"
-            except Exception as ex:
-                _LOGGER.error("Unexpected error during configuration: %s", ex)
-                errors["base"] = "unknown"
-
-            finally:
-                # Always close the client
-                try:
-                    await client.close()
-                except Exception as ex:
-                    _LOGGER.warning("Error closing client: %s", ex)
-
-        # Show the form
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
+            data_schema=self._credentials_schema(),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Allow updating API credentials without removing the config entry."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors = await async_validate_gardena_credentials(user_input)
+            if not errors:
+                return await self._apply_credential_updates(
+                    reconfigure_entry, user_input
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                self._credentials_schema(),
                 {
-                    vol.Required(CONF_CLIENT_ID): str,
-                    vol.Required(CONF_CLIENT_SECRET): str,
-                }
+                    CONF_CLIENT_ID: reconfigure_entry.data.get(CONF_CLIENT_ID, ""),
+                    CONF_CLIENT_SECRET: reconfigure_entry.data.get(
+                        CONF_CLIENT_SECRET, ""
+                    ),
+                },
             ),
             errors=errors,
-        ) 
+        )

--- a/custom_components/gardena_smart_system/const.py
+++ b/custom_components/gardena_smart_system/const.py
@@ -11,6 +11,7 @@ DOMAIN: Final = "gardena_smart_system"
 # Configuration keys
 CONF_CLIENT_ID: Final = "client_id"
 CONF_CLIENT_SECRET: Final = "client_secret"
+CONF_CONFIG_ENTRY_ID: Final = "config_entry_id"
 
 # API constants
 API_BASE_URL: Final = "https://api.smart.gardena.dev/v2"

--- a/custom_components/gardena_smart_system/credential_validation.py
+++ b/custom_components/gardena_smart_system/credential_validation.py
@@ -1,0 +1,74 @@
+"""Shared credential validation for config flow and services."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET
+
+from .auth import GardenaAuthError
+from .gardena_client import GardenaAPIError, GardenaSmartSystemClient
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_ERROR_MESSAGES: dict[str, str] = {
+    "invalid_auth": "Invalid Application Key or Client Secret",
+    "no_locations": "No Gardena locations found for these credentials",
+    "too_many_requests": "Gardena API rate limit (429) — try again later",
+    "api_error": "Gardena API error while validating credentials",
+    "unknown": "Unexpected error while validating credentials",
+}
+
+
+def dev_mode_enabled() -> bool:
+    """Return whether development mode is enabled."""
+    return os.getenv("GARDENA_DEV_MODE", "false").lower() == "true"
+
+
+async def async_validate_gardena_credentials(
+    user_input: dict[str, Any],
+) -> dict[str, str]:
+    """Validate credentials against the Gardena API. Returns error dict (may be empty)."""
+    errors: dict[str, str] = {}
+    client: GardenaSmartSystemClient | None = None
+
+    try:
+        _LOGGER.info("Testing Gardena Smart System credentials")
+        client = GardenaSmartSystemClient(
+            client_id=user_input[CONF_CLIENT_ID],
+            client_secret=user_input[CONF_CLIENT_SECRET],
+            dev_mode=dev_mode_enabled(),
+        )
+        locations = await client.get_locations()
+        if not locations:
+            _LOGGER.warning("No locations found for the provided credentials")
+            errors["base"] = "no_locations"
+        else:
+            _LOGGER.info(
+                "Successfully authenticated and found %d locations", len(locations)
+            )
+    except GardenaAuthError as ex:
+        _LOGGER.error("Authentication failed: %s", ex)
+        errors["base"] = "invalid_auth"
+    except GardenaAPIError as ex:
+        _LOGGER.error(
+            "API error during configuration: %s (status: %s)", ex, ex.status_code
+        )
+        if ex.status_code == 429:
+            errors["base"] = "too_many_requests"
+        elif ex.status_code == 404:
+            errors["base"] = "no_locations"
+        else:
+            errors["base"] = "api_error"
+    except Exception as ex:
+        _LOGGER.error("Unexpected error during configuration: %s", ex)
+        errors["base"] = "unknown"
+    finally:
+        if client is not None:
+            try:
+                await client.close()
+            except Exception as ex:
+                _LOGGER.warning("Error closing client: %s", ex)
+
+    return errors

--- a/custom_components/gardena_smart_system/manifest.json
+++ b/custom_components/gardena_smart_system/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "gardena_smart_system",
   "name": "Gardena Smart System integration",
-  "version": "3.0.7",
+  "version": "3.0.5",
   "config_flow": true,
   "documentation": "https://github.com/py-smart-gardena/hass-gardena-smart-system",
   "issue_tracker": "https://github.com/py-smart-gardena/hass-gardena-smart-system/issues",

--- a/custom_components/gardena_smart_system/manifest.json
+++ b/custom_components/gardena_smart_system/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "gardena_smart_system",
   "name": "Gardena Smart System integration",
-  "version": "3.0.5",
+  "version": "3.0.7",
   "config_flow": true,
   "documentation": "https://github.com/py-smart-gardena/hass-gardena-smart-system",
   "issue_tracker": "https://github.com/py-smart-gardena/hass-gardena-smart-system/issues",

--- a/custom_components/gardena_smart_system/services.yaml
+++ b/custom_components/gardena_smart_system/services.yaml
@@ -18,6 +18,34 @@ start_override:
 reload:
   description: Reload the Gardena Smart System integration.
 
+update_credentials:
+  description: Validate and save new Husqvarna API credentials. Works while the integration is disabled.
+  fields:
+    client_id:
+      required: true
+      example: "your-application-key"
+      selector:
+        text:
+    client_secret:
+      required: true
+      example: "your-client-secret"
+      selector:
+        text:
+    config_entry_id:
+      required: false
+      example: "01K9TMC3VVS5NHM567EPR75JN3"
+      selector:
+        text:
+
+start_reconfigure:
+  description: Open the credential configuration dialog. Works while the integration is disabled.
+  fields:
+    config_entry_id:
+      required: false
+      example: "01K9TMC3VVS5NHM567EPR75JN3"
+      selector:
+        text:
+
 websocket_diagnostics:
   description: Get WebSocket connection diagnostics and status information.
   response:

--- a/custom_components/gardena_smart_system/strings.json
+++ b/custom_components/gardena_smart_system/strings.json
@@ -32,7 +32,8 @@
   },
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reconfigure_successful": "API credentials updated. The integration was reloaded."
     },
     "error": {
       "cannot_connect": "Failed to connect, please try again.",
@@ -54,6 +55,14 @@
           "client_secret": "Application secret / Client secret"
         },
         "title": "Gardena Smart System"
+      },
+      "reconfigure": {
+        "description": "Update your Husqvarna developer application credentials. Home Assistant obtains short-lived access tokens automatically — you do not enter a Bearer token manually. Existing entities are kept.",
+        "data": {
+          "client_id": "Application Key / Client ID",
+          "client_secret": "Application secret / Client secret"
+        },
+        "title": "Update Gardena API credentials"
       }
     }
   },
@@ -95,6 +104,14 @@
     "reconnect_websocket": {
       "name": "Reconnect WebSocket",
       "description": "Force WebSocket reconnection for the Gardena Smart System integration."
+    },
+    "update_credentials": {
+      "name": "Update API credentials",
+      "description": "Validate and save new Husqvarna API credentials. Works while the integration is disabled."
+    },
+    "start_reconfigure": {
+      "name": "Configure API credentials",
+      "description": "Open the credential configuration dialog. Works while the integration is disabled."
     },
     "websocket_diagnostics": {
       "name": "WebSocket Diagnostics",

--- a/custom_components/gardena_smart_system/test_auth.py
+++ b/custom_components/gardena_smart_system/test_auth.py
@@ -515,7 +515,7 @@ class TestConfigFlowAuthentication:
     async def test_config_flow_success(self, hass):
         """Test successful config flow authentication."""
         from .config_flow import GardenaSmartSystemConfigFlow
-        from . import config_flow
+        from . import credential_validation
 
         flow = GardenaSmartSystemConfigFlow()
         flow.hass = hass
@@ -526,8 +526,8 @@ class TestConfigFlowAuthentication:
         mock_client.close = AsyncMock()
 
         # Replace the class in the module
-        original_client = config_flow.GardenaSmartSystemClient
-        config_flow.GardenaSmartSystemClient = MagicMock(return_value=mock_client)
+        original_client = credential_validation.GardenaSmartSystemClient
+        credential_validation.GardenaSmartSystemClient = MagicMock(return_value=mock_client)
 
         try:
             result = await flow.async_step_user({
@@ -540,7 +540,7 @@ class TestConfigFlowAuthentication:
             assert result["data"]["client_secret"] == "test-client-secret"
 
             # Verify the client was created with correct parameters
-            config_flow.GardenaSmartSystemClient.assert_called_once_with(
+            credential_validation.GardenaSmartSystemClient.assert_called_once_with(
                 client_id="test-client-id",
                 client_secret="test-client-secret",
                 dev_mode=False
@@ -548,14 +548,14 @@ class TestConfigFlowAuthentication:
 
         finally:
             # Restore original class
-            config_flow.GardenaSmartSystemClient = original_client
+            credential_validation.GardenaSmartSystemClient = original_client
 
     @pytest.mark.asyncio
     async def test_config_flow_invalid_auth(self, hass):
         """Test config flow with invalid authentication."""
         from .config_flow import GardenaSmartSystemConfigFlow
         from .auth import GardenaAuthError
-        from . import config_flow
+        from . import credential_validation
 
         flow = GardenaSmartSystemConfigFlow()
         flow.hass = hass
@@ -566,8 +566,8 @@ class TestConfigFlowAuthentication:
         mock_client.close = AsyncMock()
 
         # Replace the class in the module
-        original_client = config_flow.GardenaSmartSystemClient
-        config_flow.GardenaSmartSystemClient = MagicMock(return_value=mock_client)
+        original_client = credential_validation.GardenaSmartSystemClient
+        credential_validation.GardenaSmartSystemClient = MagicMock(return_value=mock_client)
 
         try:
             result = await flow.async_step_user({
@@ -581,13 +581,13 @@ class TestConfigFlowAuthentication:
 
         finally:
             # Restore original class
-            config_flow.GardenaSmartSystemClient = original_client
+            credential_validation.GardenaSmartSystemClient = original_client
 
     @pytest.mark.asyncio
     async def test_config_flow_no_locations(self, hass):
         """Test config flow with no locations found."""
         from .config_flow import GardenaSmartSystemConfigFlow
-        from . import config_flow
+        from . import credential_validation
 
         flow = GardenaSmartSystemConfigFlow()
         flow.hass = hass
@@ -598,8 +598,8 @@ class TestConfigFlowAuthentication:
         mock_client.close = AsyncMock()
 
         # Replace the class in the module
-        original_client = config_flow.GardenaSmartSystemClient
-        config_flow.GardenaSmartSystemClient = MagicMock(return_value=mock_client)
+        original_client = credential_validation.GardenaSmartSystemClient
+        credential_validation.GardenaSmartSystemClient = MagicMock(return_value=mock_client)
 
         try:
             result = await flow.async_step_user({
@@ -613,4 +613,4 @@ class TestConfigFlowAuthentication:
 
         finally:
             # Restore original class
-            config_flow.GardenaSmartSystemClient = original_client 
+            credential_validation.GardenaSmartSystemClient = original_client

--- a/custom_components/gardena_smart_system/translations/de.json
+++ b/custom_components/gardena_smart_system/translations/de.json
@@ -157,7 +157,8 @@
   },
   "config": {
     "abort": {
-      "already_configured": "Der Standort ist bereits konfiguriert"
+      "already_configured": "Der Standort ist bereits konfiguriert",
+      "reconfigure_successful": "API-Zugangsdaten aktualisiert. Die Integration wurde neu geladen."
     },
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen, bitte erneut versuchen.",
@@ -179,6 +180,14 @@
           "client_secret": "Application Secret / Client Secret"
         },
         "title": "Gardena Smart System"
+      },
+      "reconfigure": {
+        "description": "Neue Zugangsdaten der Husqvarna-Developer-App eintragen. Den kurzlebigen Access Token (Bearer) holt Home Assistant automatisch — hier kein manuelles Token nötig. Bestehende Entities bleiben erhalten.",
+        "data": {
+          "client_id": "Application Key / Client ID",
+          "client_secret": "Application Secret / Client Secret"
+        },
+        "title": "Gardena API-Zugangsdaten ändern"
       }
     }
   },
@@ -220,6 +229,14 @@
     "reconnect_websocket": {
       "name": "WebSocket neu verbinden",
       "description": "WebSocket-Verbindung für die Gardena Smart System-Integration erzwingen."
+    },
+    "update_credentials": {
+      "name": "API-Zugangsdaten aktualisieren",
+      "description": "Neue Husqvarna-API-Zugangsdaten prüfen und speichern. Funktioniert auch, wenn die Integration deaktiviert ist."
+    },
+    "start_reconfigure": {
+      "name": "API-Zugangsdaten konfigurieren",
+      "description": "Konfigurationsdialog für Zugangsdaten öffnen. Funktioniert auch, wenn die Integration deaktiviert ist."
     },
     "websocket_diagnostics": {
       "name": "WebSocket-Diagnose",

--- a/custom_components/gardena_smart_system/translations/en.json
+++ b/custom_components/gardena_smart_system/translations/en.json
@@ -157,7 +157,8 @@
   },
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reconfigure_successful": "API credentials updated. The integration was reloaded."
     },
     "error": {
       "cannot_connect": "Failed to connect, please try again.",
@@ -179,6 +180,14 @@
           "client_secret": "Application secret / Client secret"
         },
         "title": "Gardena Smart System"
+      },
+      "reconfigure": {
+        "description": "Update your Husqvarna developer application credentials. Home Assistant obtains short-lived access tokens automatically — you do not enter a Bearer token manually. Existing entities are kept.",
+        "data": {
+          "client_id": "Application Key / Client ID",
+          "client_secret": "Application secret / Client secret"
+        },
+        "title": "Update Gardena API credentials"
       }
     }
   },
@@ -220,6 +229,14 @@
     "reconnect_websocket": {
       "name": "Reconnect WebSocket",
       "description": "Force WebSocket reconnection for the Gardena Smart System integration."
+    },
+    "update_credentials": {
+      "name": "Update API credentials",
+      "description": "Validate and save new Husqvarna API credentials. Works while the integration is disabled."
+    },
+    "start_reconfigure": {
+      "name": "Configure API credentials",
+      "description": "Open the credential configuration dialog. Works while the integration is disabled."
     },
     "websocket_diagnostics": {
       "name": "WebSocket Diagnostics",


### PR DESCRIPTION
## Summary

This PR adds a way to rotate or replace Husqvarna **Application Key** and **Client Secret** without deleting and re-adding the integration.

When Husqvarna credentials expire or are rotated in the developer portal, users currently have to remove the config entry and set everything up again — losing entity IDs, automations, and dashboards. This change is meant to make that workflow safer and simpler.

## What's included

- **Reconfigure config flow** (`async_step_reconfigure`) — update credentials via the integration UI; existing entities are kept
- **Shared validation** (`credential_validation.py`) — same logic for config flow and services; includes explicit handling for HTTP 429 during validation
- **`gardena_smart_system.update_credentials`** — validate and persist new credentials via service call (also works while the integration is **disabled**)
- **`gardena_smart_system.start_reconfigure`** — open the credential dialog via service call (also while disabled)
- **Translations** — `strings.json`, `en.json`, `de.json`
- **Tests** — config flow tests updated to mock the shared validation module

No version bump in `manifest.json` — changelog entry is under `[Unreleased]`.

## Motivation

I ran into this while operating my own Home Assistant setup: after a credential change, re-adding the integration was painful. I prototyped this locally and thought it might be useful upstream as well.

**I hope some or all of this can be adopted** — happy to adjust naming, structure, docs, or scope to match project conventions. If only parts make sense (e.g. reconfigure flow without the services), that's fine too.

## Test plan

- [ ] Fresh setup via config flow still works with valid credentials
- [ ] Reconfigure flow updates credentials and reloads when the entry is enabled
- [ ] Reconfigure / `update_credentials` persist credentials when the entry is disabled (reload only after enable)
- [ ] Invalid credentials show `invalid_auth`; empty locations show `no_locations`; 429 shows `too_many_requests`
- [ ] `pytest custom_components/gardena_smart_system/test_auth.py::TestConfigFlowAuthentication`