### PR TITLE
Feature/add duration to valve pause

### DIFF
--- a/custom_components/gardena_smart_system/services.py
+++ b/custom_components/gardena_smart_system/services.py
@@ -41,6 +41,14 @@ SERVICE_SCHEMA_VALVE = vol.Schema({
     ),
 })
 
+SERVICE_SCHEMA_VALVE_PAUSE = vol.Schema({
+    vol.Optional("device_id"): cv.string,
+    vol.Optional("service_id"): cv.string,
+    vol.Optional("duration", default=1800): vol.All(
+        cv.positive_int, vol.Range(min=60)
+    ),
+})
+
 SERVICE_SCHEMA_VALVE_BASE = vol.Schema({
     vol.Optional("device_id"): cv.string,
     vol.Optional("service_id"): cv.string,
@@ -120,6 +128,9 @@ class ValveCommand(GardenaCommand):
         self.attributes["command"] = command
         if seconds and command == "START_SECONDS_TO_OVERRIDE":
             self.attributes["seconds"] = seconds
+        elif seconds and command == "PAUSE":
+            self.attributes["seconds"] = seconds
+
 
 
 class GardenaServiceManager:
@@ -207,7 +218,7 @@ class GardenaServiceManager:
             DOMAIN,
             "valve_pause",
             self._service_valve_pause,
-            schema=SERVICE_SCHEMA_VALVE_BASE,
+            schema=SERVICE_SCHEMA_VALVE_PAUSE,
         )
         self.hass.services.async_register(
             DOMAIN,
@@ -476,7 +487,8 @@ class GardenaServiceManager:
         if not service_id:
             return
 
-        command = ValveCommand(service_id, "PAUSE")
+        duration = call.data["duration"]
+        command = ValveCommand(service_id, "PAUSE", seconds=duration)
         await self._send_command(service_id, command)
 
     async def _service_valve_unpause(self, call: ServiceCall) -> None:

--- a/custom_components/gardena_smart_system/services.yaml
+++ b/custom_components/gardena_smart_system/services.yaml
@@ -82,6 +82,17 @@ valve_pause:
       example: "d8a1faef-2ee3-421d-a3f8-f8ed577c2ad3:2"
       selector:
         text:
+    duration:
+      description: Duration in seconds (must be a multiple of 60).
+      required: false
+      example: "1800"
+      default: "1800"
+      selector:
+        number:
+          min: 60
+          max: 14400
+          unit_of_measurement: seconds
+          mode: box
 
 valve_unpause:
   description: Resume automatic valve operation.


### PR DESCRIPTION
The option to set a duration will be added to the valve_pause service, as currently the automatic valve operations are only stopped for a predefined time span (30 minutes). It makes sense to have a longer time span for stopping automatic valve operations, for example when using the automatic valve to control an automatic six-way water distributor.

For backward compatibility the default value is set to 30 minutes (1800 seconds).

<img width="2436" height="872" alt="image" src="https://github.com/user-attachments/assets/be5a0c18-b022-4ead-af5b-8f98a9fc28ab" />


